### PR TITLE
Update renpy2linux.sh to work with python3

### DIFF
--- a/renpy2linux.sh
+++ b/renpy2linux.sh
@@ -23,7 +23,7 @@ else
         exit 1
     fi
 
-    RENPYVER=$(python -c 'from renpy import version_tuple; print ".".join(str(i) for i in version_tuple[:3])')
+    RENPYVER=$(python -c 'from renpy import version_tuple; print(".".join(str(i) for i in version_tuple[:3]))')
 fi
 echo "=> Ren'Py version: ${RENPYVER}"
 


### PR DESCRIPTION
I update this script to work with python3, as is default on all linux distros